### PR TITLE
Fix BoxRun docs: package name, imports, wrong examples, stale commands

### DIFF
--- a/boxrun/cli.mdx
+++ b/boxrun/cli.mdx
@@ -211,16 +211,6 @@ boxrun run node -- node -e "console.log('hello')"
 
 Run `boxrun images` to see all available aliases.
 
-## Upgrade and uninstall
-
-```bash
-# Upgrade to the latest version
-boxrun upgrade
-
-# Remove BoxRun from your system
-boxrun uninstall
-```
-
 ## Shell completions
 
 ```bash

--- a/boxrun/configuration.mdx
+++ b/boxrun/configuration.mdx
@@ -10,8 +10,9 @@ BoxRun stores all state in a single directory:
 
 ```text
 ~/.boxrun/
-├── boxrun.sock  # Unix socket (server <-> clients)
-└── boxrun.db    # SQLite (boxes, execs, event log)
+├── boxrun          # BoxRun binary (installed by install script)
+├── boxrun.db       # SQLite (boxes, execs, event log)
+└── runtime/        # BoxLite runtime (kernel, shim, libraries)
 ```
 
 No etcd, no Redis, no container runtime, no image registry.

--- a/boxrun/index.mdx
+++ b/boxrun/index.mdx
@@ -23,7 +23,7 @@ BoxRun wraps the BoxLite micro-VM runtime into a batteries-included platform —
   <Card title="Python SDK" icon="python">
     Async client for managing boxes programmatically. Create sandboxes, stream output, upload/download files.
     ```bash
-    pip install boxrun
+    pip install boxrun-sdk
     ```
   </Card>
   <Card title="REST API" icon="server">

--- a/boxrun/python-sdk.mdx
+++ b/boxrun/python-sdk.mdx
@@ -7,7 +7,7 @@ icon: "python"
 The BoxRun Python SDK provides an async client for managing boxes programmatically.
 
 ```bash
-pip install boxrun
+pip install boxrun-sdk
 ```
 
 ## Connection
@@ -19,7 +19,7 @@ The SDK auto-connects to the BoxRun server using this priority:
 3. Fallback to `127.0.0.1:9090`
 
 ```python
-from boxrun import BoxRunClient
+from boxrun_sdk import BoxRunClient
 
 # Auto-detect
 async with BoxRunClient() as client:
@@ -214,7 +214,7 @@ class BoxInfo:
 class ExecInfo:
     id: str
     box_id: str
-    status: str              # "running", "completed", "error", "timeout", "canceled"
+    status: str              # "running", "succeeded", "failed", "canceled"
     cmd: list[str]
     env: dict[str, str] | None
     workdir: str | None
@@ -254,7 +254,7 @@ class RunResult:
 All SDK errors raise `BoxRunError(code, message)`.
 
 ```python
-from boxrun.common.errors import BoxRunError
+from boxrun_sdk import BoxRunError
 
 try:
     box = await client.create("ubuntu:24.04")
@@ -315,6 +315,6 @@ async def agent_task():
 For simple one-shot tasks, use `client.run()`:
 
 ```python
-result = await client.run("ubuntu:24.04", ["python3", "-c", "print(42)"])
+result = await client.run("python", ["python3", "-c", "print(42)"])
 print(result.stdout)  # "42\n"
 ```

--- a/boxrun/quickstart.mdx
+++ b/boxrun/quickstart.mdx
@@ -118,12 +118,12 @@ Run `boxrun images` to see all aliases. Any valid OCI image reference also works
 ## Python SDK
 
 ```bash
-pip install boxrun
+pip install boxrun-sdk
 ```
 
 ```python
 import asyncio
-from boxrun import BoxRunClient
+from boxrun_sdk import BoxRunClient
 
 async def main():
     async with BoxRunClient() as client:
@@ -151,7 +151,7 @@ asyncio.run(main())
 For one-shot tasks, use `client.run()` — it creates a box, runs the command, returns output, and destroys the box:
 
 ```python
-result = await client.run("ubuntu", ["python3", "-c", "print(42)"])
+result = await client.run("python", ["python3", "-c", "print(42)"])
 print(result.stdout)  # "42\n"
 ```
 


### PR DESCRIPTION
## Summary

Verified all BoxRun documentation against the actual CLI binary (v0.2.0) and [source code](https://github.com/boxlite-ai/boxrun). Found and fixed several errors that would block new users.

### Changes

- **Package name**: `pip install boxrun` → `pip install boxrun-sdk` (matching `pyproject.toml`)
- **Import paths**: `from boxrun import` → `from boxrun_sdk import`; `from boxrun.common.errors import BoxRunError` → `from boxrun_sdk import BoxRunError`
- **Wrong image in example**: `client.run("ubuntu", ["python3", ...])` fails because `ubuntu:24.04` doesn't include `python3` → changed to `client.run("python", ...)`
- **ExecInfo status values**: `"completed"` / `"error"` → `"succeeded"` / `"failed"` (matching `store.rs` source)
- **Nonexistent commands**: Removed `boxrun upgrade` and `boxrun uninstall` sections — implemented in source but not in released v0.2.0 binary (tracked in [boxlite-ai/boxrun#1](https://github.com/boxlite-ai/boxrun/issues/1))
- **State directory**: Updated `~/.boxrun/` layout to match reality (binary, db, runtime/ — no `boxrun.sock`)

### Files changed

| File | What changed |
|------|-------------|
| `boxrun/index.mdx` | Package name |
| `boxrun/quickstart.mdx` | Package name, import, wrong image |
| `boxrun/python-sdk.mdx` | Package name, imports, exec status, wrong image, error import |
| `boxrun/cli.mdx` | Removed upgrade/uninstall |
| `boxrun/configuration.mdx` | State directory layout |

### Related issues

- boxlite-ai/boxrun#1 — `upgrade`/`uninstall` not in released binary
- boxlite-ai/boxrun#2 — Python SDK `memory_mb` default mismatch
- boxlite-ai/boxrun#3 — Python SDK `upload_file()` field name mismatch
- #1 — `--network` flag description ambiguity
- #2 — Example outputs don't match actual CLI
- #3 — seccomp warning not mentioned
- #4 — Missing `default` image alias
- #5 — Python SDK API surface incomplete
- #6 — BoxRun needs troubleshooting section

## Test plan

- [ ] Verify `pip install boxrun-sdk` works (or confirm package publishing status)
- [ ] Run quickstart Python example end-to-end with `from boxrun_sdk import`
- [ ] Confirm `boxrun completion zsh` still documented correctly after upgrade/uninstall removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)