### PR TITLE
docs: fix BoxRun install link

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -63,7 +63,7 @@ Runs on macOS (Apple Silicon), Linux (KVM), and Windows (WSL2).
 **BoxRun** is the management layer for BoxLite sandboxes. Create, list, stop, and delete boxes through a CLI, REST API, Python SDK, or web dashboard — all in a single binary.
 
 ```bash
-curl -fsSL https://boxlite.ai/boxrun/install | sh
+curl -fsSL https://sh.boxlite.ai | sh
 boxrun shell ubuntu
 ```
 


### PR DESCRIPTION
## Summary
- Replace the stale BoxRun install URL on the documentation homepage with the current sh.boxlite.ai installer endpoint.

## Why
- The published docs page points users at https://boxlite.ai/boxrun/install, which currently returns 404.
- The BoxLite repo README and CLI reference use https://sh.boxlite.ai for the installer.

Fixes boxlite-ai/boxlite#1000.

## Validation
- git diff --check
- rg -n "boxlite\.ai/boxrun/install|sh\.boxlite\.ai" index.mdx README.md getting-started reference guides tutorials architecture development
- curl -I -L https://boxlite.ai/boxrun/install returned HTTP 404
- curl -I -L https://sh.boxlite.ai returned HTTP 200

Note: npm run check could not complete locally because the Mintlify CLI was not installed; a temporary npx mint validate run hung without output and was interrupted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the BoxRun installation command to use the current installation script URL.
  * Preserved the existing one-line installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->